### PR TITLE
Michael issue063 fix log score normalization

### DIFF
--- a/handle_data/all_normalizations.py
+++ b/handle_data/all_normalizations.py
@@ -14,9 +14,10 @@ __update__ = "2025-03-20"
 import os
 from typing import List, Union
 import json as js
-from abstract_data_normalization import Normalize
+import numpy as np
 import dask
 import xarray as xr
+from abstract_data_normalization import Normalize
 
 da_or_ds = Union[xr.DataArray, xr.Dataset]
 

--- a/handle_data/all_normalizations.py
+++ b/handle_data/all_normalizations.py
@@ -9,7 +9,7 @@ General normalizer class which encapsulates all normalization based on abstract 
 __email__ = "m.langguth@fz-juelich.de"
 __author__ = "Michael Langguth"
 __date__ = "2022-10-06"
-__update__ = "2025-03-14"
+__update__ = "2025-03-20"
 
 import os
 from typing import List, Union
@@ -306,7 +306,7 @@ class Log_ZScore(Normalize):
         :param std: standard deviation of data for denormalization
         :return data_norm: denormalized data
         """
-        data = np.exp( data + np.log(self.eps)) - self.eps
         data = data * log_std + log_mu
+        data = np.exp( data + np.log(self.eps)) - self.eps
 
         return data


### PR DESCRIPTION
Corrected ordering of operations in denormalization process of logaritmic z-score normalization. 
Correct order: First undo the normalization tha invert the log-transformation -> inverse of normalization.